### PR TITLE
add support for basic authentication

### DIFF
--- a/lib/asrequest.js
+++ b/lib/asrequest.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const ntlmClient = require('ntlm-client'),
+	httpClient = require("request-promise"),
 	aswbxml = require('aswbxml'),
 	xml2js = require('xml2js'),
 	templates = require('./templates');
@@ -26,8 +27,30 @@ module.exports = function ASRequest(opts, method, cmd, template) {
 		}
 	};
 
-	if (cmd) {
+	let requestOptionsBasic = {
+		uri: opts.endpoint,
+		method: method.toUpperCase(),
+		encoding: null,
+		auth: {
+			user: opts.username,
+			pass: opts.password,
+		},
+		qs: {
+			'DeviceId': opts.device.id,
+			'DeviceType': opts.device.type
+		},
+		headers: {
+			'MS-ASProtocolVersion': opts.protocolVersion,
+			'X-MS-PolicyKey': opts.policyKey,
+			'Content-Type': 'application/vnd.ms-sync.wbxml',
+			'Accept-Language': 'en-US'
+		}
+	};
+
+	if (cmd && opts.ntlmAuth == true) {
 		requestOptions.request.qs['Cmd'] = cmd;
+	} else if (cmd && opts.ntlmAuth == false){
+		requestOptionsBasic.qs['Cmd'] = cmd;
 	}
 
 	if (template) {
@@ -40,8 +63,14 @@ module.exports = function ASRequest(opts, method, cmd, template) {
 						reject(err);
 					} else {
 						requestOptions.request.body = aswbxml.encode(parsed, 'ActiveSync');
+						requestOptionsBasic.body = aswbxml.encode(parsed, 'ActiveSync');
 						requestOptions.request.headers['Content-Type'] = 'application/vnd.ms-sync.wbxml';
-						sendRequest(requestOptions, resolve, reject);
+						if(opts.ntlmAuth == true) {
+							sendRequest(requestOptions, resolve, reject);
+						}
+						else {
+							sendRequestBasic(requestOptionsBasic, resolve, reject);
+						}
 					}
 				});
 			});
@@ -76,5 +105,19 @@ function sendRequest(requestOptions, resolve, reject) {
 	}).
 	catch(function(err) {
 		reject(err);
+	});
+}
+
+function sendRequestBasic(requestOptionsBasic, resolve, reject){
+	httpClient(requestOptionsBasic)
+	.then(function (basicResponse) {
+			let parsedResult = aswbxml.decode(basicResponse, 'ActiveSync');
+			resolve({
+				response: basicResponse,
+				body: parsedResult
+			})
+	})
+	.catch(function (err) {
+			reject(err)
 	});
 }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "merge-descriptors": "^1.0.0",
     "ntlm-client": "^0.0.5",
     "request": "^2.65.0",
+    "request-promise": "^3.0.0",
     "xml2js": "^0.4.15"
   }
 }


### PR DESCRIPTION
Add support for basic auth with ntlmAuth flag. Defaults to true.

Resolves issue #1 

``` js
const options = {
    username: '<USERNAME>',
    password: '<PASS>',
    endpoint: 'https://localhost/Microsoft-Server-ActiveSync',
    device: {
        id: 'test123',
        type: 'testdev',
    },
    ntlmAuth: false
};
```
